### PR TITLE
feat(AuthenticationService): `authenticate(with:)` result is now a completion

### DIFF
--- a/Sources/Authentication/AuthenticationService.swift
+++ b/Sources/Authentication/AuthenticationService.swift
@@ -17,5 +17,8 @@ public protocol AuthenticationService {
     associatedtype AuthenticationFailure: Error
     
     /// Authenticates a user based on some provided `Credential`.
-    func authenticate(with credential: Credential) -> Result<AuthenticationSuccess, AuthenticationFailure>
+    func authenticate(
+        with credential: Credential,
+        completion: @escaping (Result<AuthenticationSuccess, AuthenticationFailure>) -> Void
+    )
 }

--- a/Tests/AuthenticationTests/AuthenticationTests.swift
+++ b/Tests/AuthenticationTests/AuthenticationTests.swift
@@ -11,8 +11,10 @@ final class AuthenticationTests: XCTestCase {
         
         let expectedUser = ExampleAuthenticationService.User(id: "testing")
         let expectedResult: Result<ExampleAuthenticationService.User, ExampleAuthenticationService.ServiceError> = .success(expectedUser)
-        let result = service.authenticate(with: credential)
-        XCTAssertEqual(result, expectedResult)
+        
+        service.authenticate(with: credential) { (result) in
+            XCTAssertEqual(result, expectedResult)
+        }
     }
 
     static var allTests = [

--- a/Tests/AuthenticationTests/ExampleAuthenticationService.swift
+++ b/Tests/AuthenticationTests/ExampleAuthenticationService.swift
@@ -27,16 +27,14 @@ extension ExampleAuthenticationService: AuthenticationService {
         var password: String
     }
     
-    func authenticate(
-        with credential: UsernamePasswordCredential
-    ) -> Result<AuthenticationSuccess, AuthenticationFailure> {
+    func authenticate(with credential: UsernamePasswordCredential, completion: @escaping (Result<ExampleAuthenticationService.User, ExampleAuthenticationService.ServiceError>) -> Void) {
         let validUsername = credential.username == "testing"
         let validPassword = credential.password == "testing"
         
         if (validUsername && validPassword) {
-            return .success(ExampleAuthenticationService.User(id: credential.username))
+            completion(.success(ExampleAuthenticationService.User(id: credential.username)))
         } else {
-            return .failure(.invalidCredential)
+            completion(.failure(.invalidCredential))
         }
     }
 }


### PR DESCRIPTION
This ensures that the authentication attempt can be done asynchronously.